### PR TITLE
add minimum dependency feature for bert

### DIFF
--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -20,39 +20,39 @@ name = "tokenizers"
 path = "src/lib.rs"
 bench = false
 
-[[bin]]
-name = "cli"
-path = "src/cli.rs"
-bench = false
+# [[bin]]
+# name = "cli"
+# path = "src/cli.rs"
+# bench = false
 
-[[bench]]
-name = "bpe_benchmark"
-harness = false
+# [[bench]]
+# name = "bpe_benchmark"
+# harness = false
 
 [[bench]]
 name = "bert_benchmark"
 harness = false
 
 [dependencies]
-lazy_static = "1.4"
-rand = "0.7"
-onig = { version = "6.0", default-features = false }
+lazy_static = { version = "1.4", optional = true }
+rand = { version = "0.7", optional = true }
+onig = { version = "6.0", default-features = false, optional = true }
 regex = "1.3"
 regex-syntax = "0.6"
 rayon = "1.3"
 rayon-cond = { version = "*", git = "https://github.com/n1t0/rayon-cond" }
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = "1.0"
-clap = "2.33"
+# clap = "2.33"
 unicode-normalization-alignments = "0.1"
 unicode_categories = "0.1"
-unicode-segmentation = "1.6"
-indicatif = { version = "0.15", optional = true }
-itertools = "0.9"
+unicode-segmentation = { version = "1.6", optional = true }
+indicatif = { version = "0.14", optional = true }
+itertools = { version = "0.9", optional = true }
 log = "0.4"
 esaxx-rs = { version = "0.1", optional = true }
-derive_builder = "0.9"
-spm_precompiled = "0.1"
+derive_builder = { version = "0.9", optional = true }
+spm_precompiled = { version = "0.1", optional = true }
 
 [dev-dependencies]
 criterion = "0.3"
@@ -60,6 +60,15 @@ tempfile = "3.1"
 assert_approx_eq = "1.1"
 
 [features]
-default = ["progressbar", "trainer"]
-progressbar = ["indicatif"]
-trainer = ["esaxx-rs"]
+bert = []
+default = [
+    "lazy_static",
+    "rand",
+    "onig",
+    "unicode-segmentation",
+    "indicatif",
+    "itertools",
+    "esaxx-rs",
+    "derive_builder",
+    "spm_precompiled",
+]

--- a/tokenizers/README.md
+++ b/tokenizers/README.md
@@ -71,8 +71,8 @@ use std::path::Path;
 fn main() -> Result<()> {
     let vocab_size: usize = 100;
 
-    let trainer = BpeTrainerBuilder::new() // requires "trainer" feature
-        .show_progress(true) // requires "progressbar" feature
+    let trainer = BpeTrainerBuilder::new()
+        .show_progress(true)
         .vocab_size(vocab_size)
         .min_frequency(0)
         .special_tokens(vec![
@@ -113,10 +113,3 @@ fn main() -> Result<()> {
 by the total number of core/threads your CPU provides but this can be tuned by setting the `RAYON_RS_NUM_CPUS`
 environment variable. As an example setting `RAYON_RS_NUM_CPUS=4` will allocate a maximum of 4 threads.
 **_Please note this behavior may evolve in the future_**
-
-## Features
-
-- **progressbar**: The progress bar visualization is enabled by default. It might be disabled if
-compilation for certain targets is not supported or to save some binary space.
-- **trainer**: The word model trainers are enabled by default. They might be disabled if
-compilation for certain targets is not supported or to save some binary space.

--- a/tokenizers/benches/bert_benchmark.rs
+++ b/tokenizers/benches/bert_benchmark.rs
@@ -7,21 +7,22 @@ use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
 
-#[cfg(feature = "trainer")]
-use common::iter_bench_train;
-use common::{iter_bench_encode, iter_bench_encode_batch};
 use criterion::Criterion;
 use tokenizers::{
     decoders, models::wordpiece::WordPiece, normalizers::BertNormalizer,
     pre_tokenizers::bert::BertPreTokenizer, processors::bert::BertProcessing, EncodeInput, Model,
     TokenizerImpl,
 };
-#[cfg(feature = "trainer")]
+#[cfg(not(feature = "bert"))]
 use tokenizers::{
     decoders::DecoderWrapper, models::wordpiece::WordPieceTrainerBuilder,
     normalizers::NormalizerWrapper, pre_tokenizers::whitespace::Whitespace,
     processors::PostProcessorWrapper,
 };
+
+#[cfg(not(feature = "bert"))]
+use common::iter_bench_train;
+use common::{iter_bench_encode, iter_bench_encode_batch};
 
 static BATCH_SIZE: usize = 1_000;
 
@@ -73,14 +74,11 @@ pub fn bench_bert(c: &mut Criterion) {
     });
 }
 
-#[cfg(feature = "trainer")]
+#[cfg(not(feature = "bert"))]
 fn bench_train(c: &mut Criterion) {
-    #[cfg(feature = "progressbar")]
     let trainer = WordPieceTrainerBuilder::default()
         .show_progress(false)
         .build();
-    #[cfg(not(feature = "progressbar"))]
-    let trainer = WordPieceTrainerBuilder::default().build();
     type Tok = TokenizerImpl<
         WordPiece,
         NormalizerWrapper,
@@ -121,14 +119,14 @@ criterion_group! {
     targets = bench_bert
 }
 
-#[cfg(feature = "trainer")]
+#[cfg(not(feature = "bert"))]
 criterion_group! {
     name = benches_train;
     config = Criterion::default().sample_size(10);
     targets = bench_train
 }
 
-#[cfg(not(feature = "trainer"))]
-criterion_main!(bert_benches);
-#[cfg(feature = "trainer")]
+#[cfg(not(feature = "bert"))]
 criterion_main!(bert_benches, benches_train);
+#[cfg(feature = "bert")]
+criterion_main!(bert_benches);

--- a/tokenizers/benches/bpe_benchmark.rs
+++ b/tokenizers/benches/bpe_benchmark.rs
@@ -1,29 +1,24 @@
+#![cfg(not(feature = "bert"))]
+
 #[macro_use]
 extern crate criterion;
 
 mod common;
 
-use std::{
-    fs::File,
-    io::{BufRead, BufReader},
-    ops::Deref,
-    path::Path,
-};
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
 
-#[cfg(feature = "trainer")]
-use common::iter_bench_train;
-use common::{iter_bench_encode, iter_bench_encode_batch};
 use criterion::Criterion;
-#[cfg(feature = "trainer")]
-use tokenizers::{
-    models::bpe::BpeTrainerBuilder, models::TrainerWrapper, pre_tokenizers::whitespace::Whitespace,
-};
-use tokenizers::{
-    models::bpe::BPE,
-    pre_tokenizers::byte_level::ByteLevel,
-    tokenizer::{AddedToken, EncodeInput},
-    Tokenizer,
-};
+use tokenizers::models::bpe::{BpeTrainerBuilder, BPE};
+use tokenizers::models::TrainerWrapper;
+use tokenizers::pre_tokenizers::byte_level::ByteLevel;
+use tokenizers::pre_tokenizers::whitespace::Whitespace;
+use tokenizers::tokenizer::{AddedToken, EncodeInput};
+use tokenizers::Tokenizer;
+
+use common::{iter_bench_encode, iter_bench_encode_batch, iter_bench_train};
+use std::ops::Deref;
 
 static BATCH_SIZE: usize = 1_000;
 
@@ -75,15 +70,11 @@ fn bench_gpt2(c: &mut Criterion) {
     });
 }
 
-#[cfg(feature = "trainer")]
 fn bench_train(c: &mut Criterion) {
-    #[cfg(feature = "progressbar")]
     let trainer: TrainerWrapper = BpeTrainerBuilder::default()
         .show_progress(false)
         .build()
         .into();
-    #[cfg(not(feature = "progressbar"))]
-    let trainer: TrainerWrapper = BpeTrainerBuilder::default().build().into();
     let mut tokenizer = Tokenizer::new(BPE::default()).into_inner();
     tokenizer.with_pre_tokenizer(Whitespace::default());
     c.bench_function("BPE Train vocabulary (small)", |b| {
@@ -116,13 +107,9 @@ criterion_group! {
     config = Criterion::default().sample_size(20);
     targets = bench_gpt2
 }
-#[cfg(feature = "trainer")]
 criterion_group! {
     name = benches_train;
     config = Criterion::default().sample_size(10);
     targets = bench_train
 }
-#[cfg(not(feature = "trainer"))]
-criterion_main!(benches);
-#[cfg(feature = "trainer")]
 criterion_main!(benches, benches_train);

--- a/tokenizers/benches/common/mod.rs
+++ b/tokenizers/benches/common/mod.rs
@@ -2,7 +2,7 @@ use std::time::{Duration, Instant};
 
 use criterion::black_box;
 
-#[cfg(feature = "trainer")]
+#[cfg(not(feature = "bert"))]
 use tokenizers::Trainer;
 use tokenizers::{
     Decoder, EncodeInput, Model, Normalizer, PostProcessor, PreTokenizer, TokenizerImpl,
@@ -60,7 +60,7 @@ where
     duration
 }
 
-#[cfg(feature = "trainer")]
+#[cfg(not(feature = "bert"))]
 pub fn iter_bench_train<T, M, N, PT, PP, D>(
     iters: u64,
     tokenizer: &mut TokenizerImpl<M, N, PT, PP, D>,

--- a/tokenizers/src/decoders/mod.rs
+++ b/tokenizers/src/decoders/mod.rs
@@ -1,39 +1,50 @@
+#[cfg(not(feature = "bert"))]
 pub mod bpe;
 pub mod wordpiece;
 
 // Re-export these as decoders
-pub use super::pre_tokenizers::byte_level;
-pub use super::pre_tokenizers::metaspace;
+#[cfg(not(feature = "bert"))]
+pub use super::{pre_tokenizers::byte_level, pre_tokenizers::metaspace};
 
 use serde::{Deserialize, Serialize};
 
-use crate::decoders::bpe::BPEDecoder;
-use crate::decoders::wordpiece::WordPiece;
-use crate::pre_tokenizers::byte_level::ByteLevel;
-use crate::pre_tokenizers::metaspace::Metaspace;
-use crate::{Decoder, Result};
+#[cfg(not(feature = "bert"))]
+use crate::{
+    decoders::bpe::BPEDecoder, pre_tokenizers::byte_level::ByteLevel,
+    pre_tokenizers::metaspace::Metaspace,
+};
+use crate::{decoders::wordpiece::WordPiece, Decoder, Result};
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum DecoderWrapper {
+    #[cfg(not(feature = "bert"))]
     BPE(BPEDecoder),
+    #[cfg(not(feature = "bert"))]
     ByteLevel(ByteLevel),
     WordPiece(WordPiece),
+    #[cfg(not(feature = "bert"))]
     Metaspace(Metaspace),
 }
 
 impl Decoder for DecoderWrapper {
     fn decode(&self, tokens: Vec<String>) -> Result<String> {
         match self {
+            #[cfg(not(feature = "bert"))]
             DecoderWrapper::BPE(bpe) => bpe.decode(tokens),
+            #[cfg(not(feature = "bert"))]
             DecoderWrapper::ByteLevel(bl) => bl.decode(tokens),
+            #[cfg(not(feature = "bert"))]
             DecoderWrapper::Metaspace(ms) => ms.decode(tokens),
             DecoderWrapper::WordPiece(wp) => wp.decode(tokens),
         }
     }
 }
 
+#[cfg(not(feature = "bert"))]
 impl_enum_from!(BPEDecoder, DecoderWrapper, BPE);
+#[cfg(not(feature = "bert"))]
 impl_enum_from!(ByteLevel, DecoderWrapper, ByteLevel);
+#[cfg(not(feature = "bert"))]
 impl_enum_from!(Metaspace, DecoderWrapper, Metaspace);
 impl_enum_from!(WordPiece, DecoderWrapper, WordPiece);

--- a/tokenizers/src/lib.rs
+++ b/tokenizers/src/lib.rs
@@ -45,7 +45,6 @@
 //! ## Training and serialization example
 //!  
 //! ```no_run
-//! # #![cfg(all(feature = "progressbar", feature = "trainer"))]
 //! use tokenizers::decoders::DecoderWrapper;
 //! use tokenizers::models::bpe::{BpeTrainerBuilder, BPE};
 //! use tokenizers::normalizers::{strip::Strip, unicode::NFC, utils::Sequence, NormalizerWrapper};
@@ -59,8 +58,8 @@
 //! fn main() -> Result<()> {
 //!     let vocab_size: usize = 100;
 //!
-//!     let trainer = BpeTrainerBuilder::new() // requires "trainer" feature
-//!         .show_progress(true) // requires "progressbar" feature
+//!     let trainer = BpeTrainerBuilder::new()
+//!         .show_progress(true)
 //!         .vocab_size(vocab_size)
 //!         .min_frequency(0)
 //!         .special_tokens(vec![
@@ -93,8 +92,6 @@
 //!
 //!     Ok(())
 //! }
-//! # #[cfg(not(all(feature = "progressbar", feature = "trainer")))]
-//! # fn main() {}
 //! ```
 //!
 //! # Additional information
@@ -103,19 +100,14 @@
 //! by the total number of core/threads your CPU provides but this can be tuned by setting the `RAYON_RS_NUM_CPUS`
 //! environment variable. As an example setting `RAYON_RS_NUM_CPUS=4` will allocate a maximum of 4 threads.
 //! **_Please note this behavior may evolve in the future_**
-//!
-//! # Features
-//!
-//! - **progressbar**: The progress bar visualization is enabled by default. It might be disabled if
-//! compilation for certain targets is not supported or to save some binary space.
-//! - **trainer**: The word model trainers are enabled by default. They might be disabled if
-//! compilation for certain targets is not supported or to save some binary space.
 
 #[macro_use]
 extern crate log;
+#[cfg(not(feature = "bert"))]
 #[macro_use]
 extern crate lazy_static;
 
+#[cfg(not(feature = "bert"))]
 #[macro_use]
 extern crate derive_builder;
 

--- a/tokenizers/src/models/bpe/mod.rs
+++ b/tokenizers/src/models/bpe/mod.rs
@@ -3,7 +3,6 @@ use std::{convert::From, io, iter, mem};
 
 mod model;
 mod serialization;
-#[cfg(feature = "trainer")]
 mod trainer;
 mod word;
 
@@ -112,6 +111,5 @@ where
 
 // Re-export
 pub use model::*;
-#[cfg(feature = "trainer")]
 pub use trainer::*;
 use word::*;

--- a/tokenizers/src/models/bpe/word.rs
+++ b/tokenizers/src/models/bpe/word.rs
@@ -74,7 +74,6 @@ impl std::fmt::Debug for Word {
 }
 
 impl Word {
-    #[cfg(any(feature = "trainer", test))]
     pub(super) fn new() -> Self {
         Word { symbols: vec![] }
     }
@@ -104,7 +103,6 @@ impl Word {
         });
     }
 
-    #[cfg(any(feature = "trainer", test))]
     pub(super) fn merge(&mut self, c1: u32, c2: u32, replacement: u32) -> Vec<(Pair, i32)> {
         let mut changes: Vec<(Pair, i32)> = vec![];
         let mut i = 0;
@@ -242,7 +240,6 @@ impl Word {
         self.symbols.retain(|s| s.len != 0);
     }
 
-    #[cfg(any(feature = "trainer", test))]
     pub(super) fn get_chars(&self) -> Vec<u32> {
         self.symbols.iter().map(|s| s.c).collect()
     }

--- a/tokenizers/src/models/mod.rs
+++ b/tokenizers/src/models/mod.rs
@@ -1,7 +1,10 @@
 //! Popular tokenizer models.
 
+#[cfg(not(feature = "bert"))]
 pub mod bpe;
+#[cfg(not(feature = "bert"))]
 pub mod unigram;
+#[cfg(not(feature = "bert"))]
 pub mod wordlevel;
 pub mod wordpiece;
 
@@ -10,19 +13,17 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize, Serializer};
 
-#[cfg(feature = "trainer")]
-use crate::models::bpe::BpeTrainer;
-use crate::models::bpe::BPE;
-use crate::models::unigram::Unigram;
-#[cfg(feature = "trainer")]
-use crate::models::unigram::UnigramTrainer;
-use crate::models::wordlevel::WordLevel;
-use crate::models::wordpiece::WordPiece;
-#[cfg(feature = "trainer")]
-use crate::models::wordpiece::WordPieceTrainer;
-#[cfg(feature = "trainer")]
-use crate::{AddedToken, Trainer};
-use crate::{Model, Result, Token};
+use crate::{models::wordpiece::WordPiece, Model, Result, Token};
+#[cfg(not(feature = "bert"))]
+use crate::{
+    models::{
+        bpe::{BpeTrainer, BPE},
+        unigram::{Unigram, UnigramTrainer},
+        wordlevel::WordLevel,
+        wordpiece::WordPieceTrainer,
+    },
+    AddedToken, Trainer,
+};
 
 /// Wraps a vocab mapping (ID -> token) to a struct that will be serialized in order
 /// of token ID, smallest to largest.
@@ -50,23 +51,32 @@ impl<'a> Serialize for OrderedVocabIter<'a> {
 #[serde(untagged)]
 pub enum ModelWrapper {
     WordPiece(WordPiece),
+    #[cfg(not(feature = "bert"))]
     BPE(BPE),
+    #[cfg(not(feature = "bert"))]
     WordLevel(WordLevel),
+    #[cfg(not(feature = "bert"))]
     Unigram(Unigram),
 }
 
+#[cfg(not(feature = "bert"))]
 impl_enum_from!(WordLevel, ModelWrapper, WordLevel);
 impl_enum_from!(WordPiece, ModelWrapper, WordPiece);
+#[cfg(not(feature = "bert"))]
 impl_enum_from!(BPE, ModelWrapper, BPE);
+#[cfg(not(feature = "bert"))]
 impl_enum_from!(Unigram, ModelWrapper, Unigram);
 
 impl Model for ModelWrapper {
     fn tokenize(&self, tokens: &str) -> Result<Vec<Token>> {
         use ModelWrapper::*;
         match self {
+            #[cfg(not(feature = "bert"))]
             WordLevel(t) => t.tokenize(tokens),
             WordPiece(t) => t.tokenize(tokens),
+            #[cfg(not(feature = "bert"))]
             BPE(t) => t.tokenize(tokens),
+            #[cfg(not(feature = "bert"))]
             Unigram(t) => t.tokenize(tokens),
         }
     }
@@ -74,9 +84,12 @@ impl Model for ModelWrapper {
     fn token_to_id(&self, token: &str) -> Option<u32> {
         use ModelWrapper::*;
         match self {
+            #[cfg(not(feature = "bert"))]
             WordLevel(t) => t.token_to_id(token),
             WordPiece(t) => t.token_to_id(token),
+            #[cfg(not(feature = "bert"))]
             BPE(t) => t.token_to_id(token),
+            #[cfg(not(feature = "bert"))]
             Unigram(t) => t.token_to_id(token),
         }
     }
@@ -84,9 +97,12 @@ impl Model for ModelWrapper {
     fn id_to_token(&self, id: u32) -> Option<&str> {
         use ModelWrapper::*;
         match self {
+            #[cfg(not(feature = "bert"))]
             WordLevel(t) => t.id_to_token(id),
             WordPiece(t) => t.id_to_token(id),
+            #[cfg(not(feature = "bert"))]
             BPE(t) => t.id_to_token(id),
+            #[cfg(not(feature = "bert"))]
             Unigram(t) => t.id_to_token(id),
         }
     }
@@ -94,9 +110,12 @@ impl Model for ModelWrapper {
     fn get_vocab(&self) -> &HashMap<String, u32> {
         use ModelWrapper::*;
         match self {
+            #[cfg(not(feature = "bert"))]
             WordLevel(t) => t.get_vocab(),
             WordPiece(t) => t.get_vocab(),
+            #[cfg(not(feature = "bert"))]
             BPE(t) => t.get_vocab(),
+            #[cfg(not(feature = "bert"))]
             Unigram(t) => t.get_vocab(),
         }
     }
@@ -104,9 +123,12 @@ impl Model for ModelWrapper {
     fn get_vocab_size(&self) -> usize {
         use ModelWrapper::*;
         match self {
+            #[cfg(not(feature = "bert"))]
             WordLevel(t) => t.get_vocab_size(),
             WordPiece(t) => t.get_vocab_size(),
+            #[cfg(not(feature = "bert"))]
             BPE(t) => t.get_vocab_size(),
+            #[cfg(not(feature = "bert"))]
             Unigram(t) => t.get_vocab_size(),
         }
     }
@@ -114,26 +136,28 @@ impl Model for ModelWrapper {
     fn save(&self, folder: &Path, name: Option<&str>) -> Result<Vec<PathBuf>> {
         use ModelWrapper::*;
         match self {
+            #[cfg(not(feature = "bert"))]
             WordLevel(t) => t.save(folder, name),
             WordPiece(t) => t.save(folder, name),
+            #[cfg(not(feature = "bert"))]
             BPE(t) => t.save(folder, name),
+            #[cfg(not(feature = "bert"))]
             Unigram(t) => t.save(folder, name),
         }
     }
 }
 
-#[cfg(feature = "trainer")]
+#[cfg(not(feature = "bert"))]
 pub enum TrainerWrapper {
     BpeTrainer(BpeTrainer),
     WordPieceTrainer(WordPieceTrainer),
     UnigramTrainer(UnigramTrainer),
 }
 
-#[cfg(feature = "trainer")]
+#[cfg(not(feature = "bert"))]
 impl Trainer for TrainerWrapper {
     type Model = ModelWrapper;
 
-    #[cfg(feature = "progressbar")]
     fn should_show_progress(&self) -> bool {
         match self {
             TrainerWrapper::BpeTrainer(bpe) => bpe.should_show_progress(),
@@ -159,9 +183,9 @@ impl Trainer for TrainerWrapper {
     }
 }
 
-#[cfg(feature = "trainer")]
+#[cfg(not(feature = "bert"))]
 impl_enum_from!(BpeTrainer, TrainerWrapper, BpeTrainer);
-#[cfg(feature = "trainer")]
+#[cfg(not(feature = "bert"))]
 impl_enum_from!(WordPieceTrainer, TrainerWrapper, WordPieceTrainer);
-#[cfg(feature = "trainer")]
+#[cfg(not(feature = "bert"))]
 impl_enum_from!(UnigramTrainer, TrainerWrapper, UnigramTrainer);

--- a/tokenizers/src/models/unigram/mod.rs
+++ b/tokenizers/src/models/unigram/mod.rs
@@ -2,11 +2,9 @@
 mod lattice;
 mod model;
 mod serialization;
-#[cfg(feature = "trainer")]
 mod trainer;
 mod trie;
 
 pub use lattice::*;
 pub use model::*;
-#[cfg(feature = "trainer")]
 pub use trainer::*;

--- a/tokenizers/src/models/wordpiece/mod.rs
+++ b/tokenizers/src/models/wordpiece/mod.rs
@@ -1,6 +1,7 @@
 //! [WordPiece](https://static.googleusercontent.com/media/research.google.com/en//pubs/archive/37842.pdf)
 //! model.
 
+#[cfg(not(feature = "bert"))]
 use crate::models::bpe::BPE;
 use crate::tokenizer::{Model, Result, Token};
 use std::{
@@ -14,9 +15,9 @@ use std::{
 };
 
 mod serialization;
-#[cfg(feature = "trainer")]
+#[cfg(not(feature = "bert"))]
 mod trainer;
-#[cfg(feature = "trainer")]
+#[cfg(not(feature = "bert"))]
 pub use trainer::*;
 
 #[derive(Debug)]
@@ -185,6 +186,7 @@ impl WordPiece {
         WordPiece::builder().files(vocab.to_owned())
     }
 
+    #[cfg(not(feature = "bert"))]
     /// Create a `WordPiece` model from a `BPE` model.
     pub fn from_bpe(bpe: &BPE) -> Self {
         let mut wp = Self::builder()

--- a/tokenizers/src/models/wordpiece/trainer.rs
+++ b/tokenizers/src/models/wordpiece/trainer.rs
@@ -35,7 +35,6 @@ impl WordPieceTrainerBuilder {
         self
     }
 
-    #[cfg(feature = "progressbar")]
     /// Set whether to show progress
     pub fn show_progress(mut self, show: bool) -> Self {
         self.bpe_trainer_builder = self.bpe_trainer_builder.show_progress(show);
@@ -108,7 +107,6 @@ impl Trainer for WordPieceTrainer {
         self.bpe_trainer.process_tokens(&mut words, tokens)
     }
 
-    #[cfg(feature = "progressbar")]
     fn should_show_progress(&self) -> bool {
         self.bpe_trainer.should_show_progress()
     }

--- a/tokenizers/src/normalizers/mod.rs
+++ b/tokenizers/src/normalizers/mod.rs
@@ -1,36 +1,57 @@
 pub mod bert;
+#[cfg(not(feature = "bert"))]
 pub mod precompiled;
+#[cfg(not(feature = "bert"))]
 pub mod replace;
+#[cfg(not(feature = "bert"))]
 pub mod strip;
+#[cfg(not(feature = "bert"))]
 pub mod unicode;
 pub mod utils;
 
-pub use crate::normalizers::bert::BertNormalizer;
-pub use crate::normalizers::precompiled::Precompiled;
-pub use crate::normalizers::replace::Replace;
-pub use crate::normalizers::strip::{Strip, StripAccents};
-pub use crate::normalizers::unicode::{Nmt, NFC, NFD, NFKC, NFKD};
-pub use crate::normalizers::utils::{Lowercase, Sequence};
+#[cfg(not(feature = "bert"))]
+pub use crate::normalizers::{
+    precompiled::Precompiled,
+    replace::Replace,
+    strip::{Strip, StripAccents},
+    unicode::{Nmt, NFC, NFD, NFKC, NFKD},
+};
+pub use crate::{
+    normalizers::{
+        bert::BertNormalizer,
+        utils::{Lowercase, Sequence},
+    },
+    NormalizedString, Normalizer,
+};
 
 use serde::{Deserialize, Serialize};
-
-use crate::{NormalizedString, Normalizer};
 
 /// Wrapper for known Normalizers.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum NormalizerWrapper {
     BertNormalizer(BertNormalizer),
+    #[cfg(not(feature = "bert"))]
     StripNormalizer(Strip),
+    #[cfg(not(feature = "bert"))]
     StripAccents(StripAccents),
+    #[cfg(not(feature = "bert"))]
     NFC(NFC),
+    #[cfg(not(feature = "bert"))]
     NFD(NFD),
+    #[cfg(not(feature = "bert"))]
     NFKC(NFKC),
+    #[cfg(not(feature = "bert"))]
     NFKD(NFKD),
+    #[cfg(not(feature = "bert"))]
     Sequence(Sequence),
+    #[cfg(not(feature = "bert"))]
     Lowercase(Lowercase),
+    #[cfg(not(feature = "bert"))]
     Nmt(Nmt),
+    #[cfg(not(feature = "bert"))]
     Precompiled(Precompiled),
+    #[cfg(not(feature = "bert"))]
     Replace(Replace),
 }
 
@@ -38,30 +59,52 @@ impl Normalizer for NormalizerWrapper {
     fn normalize(&self, normalized: &mut NormalizedString) -> crate::Result<()> {
         match self {
             NormalizerWrapper::BertNormalizer(bn) => bn.normalize(normalized),
+            #[cfg(not(feature = "bert"))]
             NormalizerWrapper::StripNormalizer(sn) => sn.normalize(normalized),
+            #[cfg(not(feature = "bert"))]
             NormalizerWrapper::StripAccents(sn) => sn.normalize(normalized),
+            #[cfg(not(feature = "bert"))]
             NormalizerWrapper::NFC(nfc) => nfc.normalize(normalized),
+            #[cfg(not(feature = "bert"))]
             NormalizerWrapper::NFD(nfd) => nfd.normalize(normalized),
+            #[cfg(not(feature = "bert"))]
             NormalizerWrapper::NFKC(nfkc) => nfkc.normalize(normalized),
+            #[cfg(not(feature = "bert"))]
             NormalizerWrapper::NFKD(nfkd) => nfkd.normalize(normalized),
+            #[cfg(not(feature = "bert"))]
             NormalizerWrapper::Sequence(sequence) => sequence.normalize(normalized),
+            #[cfg(not(feature = "bert"))]
             NormalizerWrapper::Lowercase(lc) => lc.normalize(normalized),
+            #[cfg(not(feature = "bert"))]
             NormalizerWrapper::Nmt(lc) => lc.normalize(normalized),
+            #[cfg(not(feature = "bert"))]
             NormalizerWrapper::Precompiled(lc) => lc.normalize(normalized),
+            #[cfg(not(feature = "bert"))]
             NormalizerWrapper::Replace(lc) => lc.normalize(normalized),
         }
     }
 }
 
 impl_enum_from!(BertNormalizer, NormalizerWrapper, BertNormalizer);
+#[cfg(not(feature = "bert"))]
 impl_enum_from!(NFKD, NormalizerWrapper, NFKD);
+#[cfg(not(feature = "bert"))]
 impl_enum_from!(NFKC, NormalizerWrapper, NFKC);
+#[cfg(not(feature = "bert"))]
 impl_enum_from!(NFC, NormalizerWrapper, NFC);
+#[cfg(not(feature = "bert"))]
 impl_enum_from!(NFD, NormalizerWrapper, NFD);
+#[cfg(not(feature = "bert"))]
 impl_enum_from!(Strip, NormalizerWrapper, StripNormalizer);
+#[cfg(not(feature = "bert"))]
 impl_enum_from!(StripAccents, NormalizerWrapper, StripAccents);
+#[cfg(not(feature = "bert"))]
 impl_enum_from!(Sequence, NormalizerWrapper, Sequence);
+#[cfg(not(feature = "bert"))]
 impl_enum_from!(Lowercase, NormalizerWrapper, Lowercase);
+#[cfg(not(feature = "bert"))]
 impl_enum_from!(Nmt, NormalizerWrapper, Nmt);
+#[cfg(not(feature = "bert"))]
 impl_enum_from!(Precompiled, NormalizerWrapper, Precompiled);
+#[cfg(not(feature = "bert"))]
 impl_enum_from!(Replace, NormalizerWrapper, Replace);

--- a/tokenizers/src/pre_tokenizers/mod.rs
+++ b/tokenizers/src/pre_tokenizers/mod.rs
@@ -1,38 +1,57 @@
 pub mod bert;
+#[cfg(not(feature = "bert"))]
 pub mod byte_level;
+#[cfg(not(feature = "bert"))]
 pub mod delimiter;
+#[cfg(not(feature = "bert"))]
 pub mod digits;
+#[cfg(not(feature = "bert"))]
 pub mod metaspace;
+#[cfg(not(feature = "bert"))]
 pub mod punctuation;
+#[cfg(not(feature = "bert"))]
 pub mod sequence;
+#[cfg(not(feature = "bert"))]
 pub mod unicode_scripts;
+#[cfg(not(feature = "bert"))]
 pub mod whitespace;
 
 use serde::{Deserialize, Serialize};
 
-use crate::pre_tokenizers::bert::BertPreTokenizer;
-use crate::pre_tokenizers::byte_level::ByteLevel;
-use crate::pre_tokenizers::delimiter::CharDelimiterSplit;
-use crate::pre_tokenizers::digits::Digits;
-use crate::pre_tokenizers::metaspace::Metaspace;
-use crate::pre_tokenizers::punctuation::Punctuation;
-use crate::pre_tokenizers::sequence::Sequence;
-use crate::pre_tokenizers::unicode_scripts::UnicodeScripts;
-use crate::pre_tokenizers::whitespace::{Whitespace, WhitespaceSplit};
-use crate::{PreTokenizedString, PreTokenizer};
+#[cfg(not(feature = "bert"))]
+use crate::pre_tokenizers::{
+    byte_level::ByteLevel,
+    delimiter::CharDelimiterSplit,
+    digits::Digits,
+    metaspace::Metaspace,
+    punctuation::Punctuation,
+    sequence::Sequence,
+    unicode_scripts::UnicodeScripts,
+    whitespace::{Whitespace, WhitespaceSplit},
+};
+use crate::{pre_tokenizers::bert::BertPreTokenizer, PreTokenizedString, PreTokenizer};
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(untagged)]
 pub enum PreTokenizerWrapper {
     BertPreTokenizer(BertPreTokenizer),
+    #[cfg(not(feature = "bert"))]
     ByteLevel(ByteLevel),
+    #[cfg(not(feature = "bert"))]
     Delimiter(CharDelimiterSplit),
+    #[cfg(not(feature = "bert"))]
     Metaspace(Metaspace),
+    #[cfg(not(feature = "bert"))]
     Whitespace(Whitespace),
+    #[cfg(not(feature = "bert"))]
     Sequence(Sequence),
+    #[cfg(not(feature = "bert"))]
     Punctuation(Punctuation),
+    #[cfg(not(feature = "bert"))]
     WhitespaceSplit(WhitespaceSplit),
+    #[cfg(not(feature = "bert"))]
     Digits(Digits),
+    #[cfg(not(feature = "bert"))]
     UnicodeScripts(UnicodeScripts),
 }
 
@@ -40,26 +59,44 @@ impl PreTokenizer for PreTokenizerWrapper {
     fn pre_tokenize(&self, normalized: &mut PreTokenizedString) -> crate::Result<()> {
         match self {
             PreTokenizerWrapper::BertPreTokenizer(bpt) => bpt.pre_tokenize(normalized),
+            #[cfg(not(feature = "bert"))]
             PreTokenizerWrapper::ByteLevel(bpt) => bpt.pre_tokenize(normalized),
+            #[cfg(not(feature = "bert"))]
             PreTokenizerWrapper::Delimiter(dpt) => dpt.pre_tokenize(normalized),
+            #[cfg(not(feature = "bert"))]
             PreTokenizerWrapper::Metaspace(mspt) => mspt.pre_tokenize(normalized),
+            #[cfg(not(feature = "bert"))]
             PreTokenizerWrapper::Whitespace(wspt) => wspt.pre_tokenize(normalized),
+            #[cfg(not(feature = "bert"))]
             PreTokenizerWrapper::Punctuation(tok) => tok.pre_tokenize(normalized),
+            #[cfg(not(feature = "bert"))]
             PreTokenizerWrapper::Sequence(tok) => tok.pre_tokenize(normalized),
+            #[cfg(not(feature = "bert"))]
             PreTokenizerWrapper::WhitespaceSplit(wspt) => wspt.pre_tokenize(normalized),
+            #[cfg(not(feature = "bert"))]
             PreTokenizerWrapper::Digits(wspt) => wspt.pre_tokenize(normalized),
+            #[cfg(not(feature = "bert"))]
             PreTokenizerWrapper::UnicodeScripts(us) => us.pre_tokenize(normalized),
         }
     }
 }
 
 impl_enum_from!(BertPreTokenizer, PreTokenizerWrapper, BertPreTokenizer);
+#[cfg(not(feature = "bert"))]
 impl_enum_from!(ByteLevel, PreTokenizerWrapper, ByteLevel);
+#[cfg(not(feature = "bert"))]
 impl_enum_from!(CharDelimiterSplit, PreTokenizerWrapper, Delimiter);
+#[cfg(not(feature = "bert"))]
 impl_enum_from!(Whitespace, PreTokenizerWrapper, Whitespace);
+#[cfg(not(feature = "bert"))]
 impl_enum_from!(Punctuation, PreTokenizerWrapper, Punctuation);
+#[cfg(not(feature = "bert"))]
 impl_enum_from!(Sequence, PreTokenizerWrapper, Sequence);
+#[cfg(not(feature = "bert"))]
 impl_enum_from!(Metaspace, PreTokenizerWrapper, Metaspace);
+#[cfg(not(feature = "bert"))]
 impl_enum_from!(WhitespaceSplit, PreTokenizerWrapper, WhitespaceSplit);
+#[cfg(not(feature = "bert"))]
 impl_enum_from!(Digits, PreTokenizerWrapper, Digits);
+#[cfg(not(feature = "bert"))]
 impl_enum_from!(UnicodeScripts, PreTokenizerWrapper, UnicodeScripts);

--- a/tokenizers/src/processors/mod.rs
+++ b/tokenizers/src/processors/mod.rs
@@ -1,25 +1,32 @@
 pub mod bert;
+#[cfg(not(feature = "bert"))]
 pub mod roberta;
+#[cfg(not(feature = "bert"))]
 pub mod template;
 
 // Re-export these as processors
+#[cfg(not(feature = "bert"))]
 pub use super::pre_tokenizers::byte_level;
 
 use serde::{Deserialize, Serialize};
 
-use crate::pre_tokenizers::byte_level::ByteLevel;
-use crate::processors::bert::BertProcessing;
-use crate::processors::roberta::RobertaProcessing;
-use crate::processors::template::TemplateProcessing;
-use crate::{Encoding, PostProcessor, Result};
+#[cfg(not(feature = "bert"))]
+use crate::{
+    pre_tokenizers::byte_level::ByteLevel,
+    processors::{roberta::RobertaProcessing, template::TemplateProcessing},
+};
+use crate::{processors::bert::BertProcessing, Encoding, PostProcessor, Result};
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 #[serde(untagged)]
 pub enum PostProcessorWrapper {
     // Roberta must be before Bert for deserialization (serde does not validate tags)
+    #[cfg(not(feature = "bert"))]
     Roberta(RobertaProcessing),
     Bert(BertProcessing),
+    #[cfg(not(feature = "bert"))]
     ByteLevel(ByteLevel),
+    #[cfg(not(feature = "bert"))]
     Template(TemplateProcessing),
 }
 
@@ -27,8 +34,11 @@ impl PostProcessor for PostProcessorWrapper {
     fn added_tokens(&self, is_pair: bool) -> usize {
         match self {
             PostProcessorWrapper::Bert(bert) => bert.added_tokens(is_pair),
+            #[cfg(not(feature = "bert"))]
             PostProcessorWrapper::ByteLevel(bl) => bl.added_tokens(is_pair),
+            #[cfg(not(feature = "bert"))]
             PostProcessorWrapper::Roberta(roberta) => roberta.added_tokens(is_pair),
+            #[cfg(not(feature = "bert"))]
             PostProcessorWrapper::Template(template) => template.added_tokens(is_pair),
         }
     }
@@ -43,12 +53,15 @@ impl PostProcessor for PostProcessorWrapper {
             PostProcessorWrapper::Bert(bert) => {
                 bert.process(encoding, pair_encoding, add_special_tokens)
             }
+            #[cfg(not(feature = "bert"))]
             PostProcessorWrapper::ByteLevel(bl) => {
                 bl.process(encoding, pair_encoding, add_special_tokens)
             }
+            #[cfg(not(feature = "bert"))]
             PostProcessorWrapper::Roberta(roberta) => {
                 roberta.process(encoding, pair_encoding, add_special_tokens)
             }
+            #[cfg(not(feature = "bert"))]
             PostProcessorWrapper::Template(template) => {
                 template.process(encoding, pair_encoding, add_special_tokens)
             }
@@ -57,14 +70,19 @@ impl PostProcessor for PostProcessorWrapper {
 }
 
 impl_enum_from!(BertProcessing, PostProcessorWrapper, Bert);
+#[cfg(not(feature = "bert"))]
 impl_enum_from!(ByteLevel, PostProcessorWrapper, ByteLevel);
+#[cfg(not(feature = "bert"))]
 impl_enum_from!(RobertaProcessing, PostProcessorWrapper, Roberta);
+#[cfg(not(feature = "bert"))]
 impl_enum_from!(TemplateProcessing, PostProcessorWrapper, Template);
 
 #[cfg(test)]
 mod tests {
+    #[cfg(not(feature = "bert"))]
     use super::*;
 
+    #[cfg(not(feature = "bert"))]
     #[test]
     fn deserialize_bert_roberta_correctly() {
         let roberta = RobertaProcessing::default();

--- a/tokenizers/src/tokenizer/encoding.rs
+++ b/tokenizers/src/tokenizer/encoding.rs
@@ -144,6 +144,7 @@ impl Encoding {
         std::mem::replace(&mut self.overflowing, vec![])
     }
 
+    #[cfg(not(feature = "bert"))]
     pub(crate) fn process_tokens_with_offsets_mut<F>(&mut self, func: F)
     where
         F: FnMut((usize, (&String, &mut Offsets))),

--- a/tokenizers/src/tokenizer/normalizer.rs
+++ b/tokenizers/src/tokenizer/normalizer.rs
@@ -122,7 +122,7 @@ pub struct NormalizedString {
 }
 
 impl NormalizedString {
-    #[cfg(test)]
+    #[cfg(all(test, not(feature = "bert")))]
     pub(crate) fn new(
         original: String,
         normalized: String,

--- a/tokenizers/src/tokenizer/pattern.rs
+++ b/tokenizers/src/tokenizer/pattern.rs
@@ -59,6 +59,7 @@ impl Pattern for &Regex {
     }
 }
 
+#[cfg(not(feature = "bert"))]
 impl Pattern for &onig::Regex {
     fn find_matches(&self, inside: &str) -> Result<Vec<(Offsets, bool)>> {
         if inside.is_empty() {
@@ -204,6 +205,7 @@ mod tests {
         do_test!("aaa", &is_whitespace => vec![((0, 3), false)]);
     }
 
+    #[cfg(not(feature = "bert"))]
     #[test]
     fn onig_regex() {
         let is_whitespace = onig::Regex::new(r"\s+").unwrap();

--- a/tokenizers/src/utils/mod.rs
+++ b/tokenizers/src/utils/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(not(feature = "bert"))]
 pub mod cache;
 pub mod iter;
 pub mod padding;

--- a/tokenizers/tests/added_tokens.rs
+++ b/tokenizers/tests/added_tokens.rs
@@ -1,3 +1,5 @@
+#![cfg(not(feature = "bert"))]
+
 mod common;
 
 use common::*;

--- a/tokenizers/tests/common/mod.rs
+++ b/tokenizers/tests/common/mod.rs
@@ -1,3 +1,5 @@
+#![cfg(not(feature = "bert"))]
+
 use tokenizers::decoders::wordpiece::WordPiece as WordPieceDecoder;
 use tokenizers::models::bpe::BPE;
 use tokenizers::models::wordpiece::WordPiece;

--- a/tokenizers/tests/documentation.rs
+++ b/tokenizers/tests/documentation.rs
@@ -1,14 +1,12 @@
-use tokenizers::Tokenizer;
-#[cfg(feature = "trainer")]
-use tokenizers::{
-    models::bpe::{BpeTrainerBuilder, BPE},
-    normalizers::{Sequence, Strip, NFC},
-    pre_tokenizers::byte_level::ByteLevel,
-    AddedToken, DecoderWrapper, NormalizerWrapper, PostProcessorWrapper, PreTokenizerWrapper,
-    TokenizerBuilder, TokenizerImpl,
-};
+#![cfg(not(feature = "bert"))]
 
-#[cfg(feature = "trainer")]
+use tokenizers::models::bpe::{BpeTrainerBuilder, BPE};
+use tokenizers::normalizers::{Sequence, Strip, NFC};
+use tokenizers::pre_tokenizers::byte_level::ByteLevel;
+use tokenizers::{AddedToken, TokenizerBuilder};
+use tokenizers::{DecoderWrapper, NormalizerWrapper, PostProcessorWrapper, PreTokenizerWrapper};
+use tokenizers::{Tokenizer, TokenizerImpl};
+
 #[test]
 fn train_tokenizer() {
     let vocab_size: usize = 100;
@@ -24,21 +22,8 @@ fn train_tokenizer() {
         .build()
         .unwrap();
 
-    #[cfg(feature = "progressbar")]
     let trainer = BpeTrainerBuilder::new()
         .show_progress(false)
-        .vocab_size(vocab_size)
-        .min_frequency(0)
-        .special_tokens(vec![
-            AddedToken::from(String::from("<s>"), true),
-            AddedToken::from(String::from("<pad>"), true),
-            AddedToken::from(String::from("</s>"), true),
-            AddedToken::from(String::from("<unk>"), true),
-            AddedToken::from(String::from("<mask>"), true),
-        ])
-        .build();
-    #[cfg(not(feature = "progressbar"))]
-    let trainer = BpeTrainerBuilder::new()
         .vocab_size(vocab_size)
         .min_frequency(0)
         .special_tokens(vec![
@@ -75,7 +60,6 @@ fn load_tokenizer() {
     assert_eq!(decoded, example);
 }
 
-#[cfg(feature = "trainer")]
 #[test]
 #[ignore]
 fn quicktour_slow_train() -> tokenizers::Result<()> {
@@ -386,7 +370,6 @@ fn pipeline() -> tokenizers::Result<()> {
     Ok(())
 }
 
-#[cfg(feature = "trainer")]
 #[test]
 #[ignore]
 fn train_pipeline_bert() -> tokenizers::Result<()> {

--- a/tokenizers/tests/offsets.rs
+++ b/tokenizers/tests/offsets.rs
@@ -1,3 +1,5 @@
+#![cfg(not(feature = "bert"))]
+
 mod common;
 
 use common::*;

--- a/tokenizers/tests/serialization.rs
+++ b/tokenizers/tests/serialization.rs
@@ -1,3 +1,5 @@
+#![cfg(not(feature = "bert"))]
+
 mod common;
 
 use common::*;

--- a/tokenizers/tests/unigram.rs
+++ b/tokenizers/tests/unigram.rs
@@ -1,16 +1,15 @@
+#![cfg(not(feature = "bert"))]
+
 #[cfg(not(debug_assertions))]
 use assert_approx_eq::assert_approx_eq;
+use std::collections::HashMap;
+use std::fs::read_to_string;
 use std::path::Path;
-#[cfg(feature = "trainer")]
-use std::{collections::HashMap, fs::read_to_string};
 #[cfg(not(debug_assertions))]
 use tokenizers::models::unigram::Lattice;
 use tokenizers::models::unigram::Unigram;
-#[cfg(feature = "trainer")]
 use tokenizers::models::unigram::UnigramTrainer;
-use tokenizers::tokenizer::Model;
-#[cfg(feature = "trainer")]
-use tokenizers::tokenizer::Trainer;
+use tokenizers::tokenizer::{Model, Trainer};
 
 #[test]
 fn test_unigram_from_file() {
@@ -41,7 +40,6 @@ fn test_unigram_from_file() {
     );
 }
 
-#[cfg(feature = "trainer")]
 #[test]
 fn test_train_unigram_from_file() {
     let content = read_to_string("data/small.txt").unwrap();
@@ -54,14 +52,8 @@ fn test_train_unigram_from_file() {
 
     // println!("Words counts {:?}", word_counts);
 
-    #[cfg(feature = "progressbar")]
     let trainer = UnigramTrainer::builder()
         .show_progress(false)
-        .unk_token(Some("<UNK>".into()))
-        .build()
-        .unwrap();
-    #[cfg(not(feature = "progressbar"))]
-    let trainer = UnigramTrainer::builder()
         .unk_token(Some("<UNK>".into()))
         .build()
         .unwrap();


### PR DESCRIPTION
strips the tokenizers from everything not needed for a bert tokenizer when the `bert` feature is enabled (and default features are disabled).